### PR TITLE
bugfix/repo-search-by-tags-not-working: This fixes the issue where search by tags wwas returning an error

### DIFF
--- a/src/main/kotlin/io/taggit/DAO.kt
+++ b/src/main/kotlin/io/taggit/DAO.kt
@@ -182,7 +182,7 @@ object DAO {
                     GitStarsRepo(
                         id = it.getObject("id") as UUID,
                         userId = it.getObject("user_id") as UUID,
-                        repoId = it.getLong("repoId"),
+                        repoId = it.getLong("repo_id"),
                         repoName = it.getString("repo_name"),
                         githubLink = it.getString("github_link"),
                         githubDescription = it.getString("github_description"),


### PR DESCRIPTION
The error was caused by a wrong column name mapping, specifically `repo_id` when returning the repo data using tags