### PR TITLE
bugfix/fix-thanos-issue: Fixes the issue which caused existing healthy users to fade away

### DIFF
--- a/src/main/kotlin/io/taggit/db/DAO.kt
+++ b/src/main/kotlin/io/taggit/db/DAO.kt
@@ -85,6 +85,9 @@ object DAO {
                 UsersTable.tokenRefreshedAt to LocalDateTime.now()
                 UsersTable.lastLoginAt to LocalDateTime.now()
                 UsersTable.updatedAt to LocalDateTime.now()
+                where {
+                    it.githubUserId eq githubUser.id
+                }
             }
         } else {
             UsersTable.update {
@@ -92,6 +95,9 @@ object DAO {
                 UsersTable.githubUserName to githubUser.login
                 UsersTable.email to githubUser.email
                 UsersTable.lastLoginAt to LocalDateTime.now()
+                where {
+                    it.githubUserId eq githubUser.id
+                }
             }
         }
     }


### PR DESCRIPTION
This is called thanos issue because of a bug in the update query which didn't have the github user id causing all existing users to be updated each time a user signed in.

I didn't catch this bug on my local because I was only testing with a single user, mine. (:big-facepalm-emoji:)